### PR TITLE
Support OpenBSD

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -10,7 +10,7 @@ var _ = require('sdk/l10n').get;
 var platform = require('sdk/system').platform;
 var prefService = Cc['@mozilla.org/preferences-service;1']
   .getService(Ci.nsIPrefService);
-var desktop = ['winnt', 'linux', 'darwin'].indexOf(platform) !== -1;
+var desktop = ['winnt', 'linux', 'darwin', 'openbsd'].indexOf(platform) !== -1;
 
 var prefs = (function () {
   var p = require('sdk/preferences/service');


### PR DESCRIPTION
Load the desktop.js code instead of the android version by adding openbsd to the sdk/system platform check. This allows the add-on to run on OpenBSD.

Original error was:

console.error: ipsettings:
  Message: TypeError: getNativeWindow(...) is undefined
  Stack:
    @resource://jid1-ckhysaadh4nl6q-at-jetpack/ipsettings/lib/android.js:54:10
CuddlefishLoader/options<.load@resource://gre/modules/commonjs/sdk/loader/cuddlefish.js:79:18
@resource://jid1-ckhysaadh4nl6q-at-jetpack/ipsettings/lib/main.js:146:47
CuddlefishLoader/options<.load@resource://gre/modules/commonjs/sdk/loader/cuddlefish.js:79:18
run@resource://gre/modules/commonjs/sdk/addon/runner.js:145:19
startup/</<@resource://gre/modules/commonjs/sdk/addon/runner.js:86:7
Handler.prototype.process@resource://gre/modules/Promise-backend.js:922:23
this.PromiseWalker.walkerLoop@resource://gre/modules/Promise-backend.js:801:7
this.PromiseWalker.scheduleWalkerLoop/<@resource://gre/modules/Promise-backend.js:740:39

*************************
A coding exception was thrown in a Promise resolution callback.
See https://developer.mozilla.org/Mozilla/JavaScript_code_modules/Promise.jsm/Promise

Full message: TypeError: getNativeWindow(...) is undefined
Full stack:
@resource://jid1-ckhysaadh4nl6q-at-jetpack/ipsettings/lib/android.js:54:10
CuddlefishLoader/options<.load@resource://gre/modules/commonjs/sdk/loader/cuddlefish.js:79:18
@resource://jid1-ckhysaadh4nl6q-at-jetpack/ipsettings/lib/main.js:146:47
CuddlefishLoader/options<.load@resource://gre/modules/commonjs/sdk/loader/cuddlefish.js:79:18
run@resource://gre/modules/commonjs/sdk/addon/runner.js:145:19
startup/</<@resource://gre/modules/commonjs/sdk/addon/runner.js:86:7
Handler.prototype.process@resource://gre/modules/Promise-backend.js:922:23
this.PromiseWalker.walkerLoop@resource://gre/modules/Promise-backend.js:801:7
this.PromiseWalker.scheduleWalkerLoop/<@resource://gre/modules/Promise-backend.js:740:39
